### PR TITLE
Add Steer, Don't Solve method to Sec4.2 Task: Code Agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,7 @@ KL penalty corresponds to penalizing the KL divergence between the learned polic
 | DeepAnalyze | Outcome | DeepSeek-R1-Distill-Qwen3-8B | [Paper](https://arxiv.org/abs/2510.16872) | [Code](https://github.com/ruc-datalab/DeepAnalyze) |
 | Golubev et al. | Process | Qwen2.5-72B-Instruct | [Paper](https://arxiv.org/abs/2508.03501) | - |
 | SWEET-RL | Process | Llama-3.1-8B/70B-Instruct | [Paper](https://arxiv.org/abs/2503.15478) | [Code](https://github.com/facebookresearch/sweet_rl) |
+| Steer, Don't Solve | Process | Qwen3-4B / Qwen3-8B | [Paper](https://arxiv.org/abs/2606.21811) | [Code](https://github.com/shubhamrgandhi/critic-training) [Model](https://huggingface.co/code-critic-model) |
 
 ---
 


### PR DESCRIPTION
This PR adds our paper to Sec4.2 Task: Code Agent, in the "RL for Automated Software Engineering (SWE)" subgroup next to the other process-feedback rows (SWEET-RL, Golubev et al.).

**Steer, Don't Solve: Training Small Critic Models for Large Code Agents**
Shubham Gandhi, Yiqing Xie, Atharva Naik, Ruichen Zhu, Carolyn Rose (Carnegie Mellon University). arXiv, 2026.

- Paper: https://arxiv.org/abs/2606.21811
- Code: https://github.com/shubhamrgandhi/critic-training
- Models and data: https://huggingface.co/code-critic-model

We train small (4B and 8B) critic models with SFT and DPO to identify errors in a coding agent's trajectory and give high-level guidance every k steps at inference time, without generating actions themselves. The critics improve SWE-bench Verified resolve rates of six larger coding agents (for example, +16.0 points for GLM-4.7-Flash-30B-A3B and +14.4 for GPT-OSS-120B) and lower inference cost for some agents by finishing tasks in fewer steps.

Column choices: reward type is "Process" because the critic scores and corrects intermediate steps of the trajectory; base LLM is the critic's base (Qwen3-4B / Qwen3-8B). The critic is trained with SFT plus DPO (the DPO family in your algorithm table) rather than online RL. Happy to adjust the row or its placement.