### PR TITLE
Add DRACO: Fine-Grained Credit Assignment with Dynamic Rubrics for Long-Horizon Agent Training

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ KL penalty corresponds to penalizing the KL divergence between the learned polic
 | PAPO | 2025 | Surrogate of GRPO's | Yes | Yes | Implicit Perception Loss | Group-based reward | [Paper](https://arxiv.org/pdf/2507.06448) | [Code](https://github.com/MikeWangWZHL/PAPO) [Model](https://huggingface.co/collections/PAPOGalaxy/papo-qwen-686d92dd3d43b1ce698f851a) [Website](https://mikewangwzhl.github.io/PAPO/) |
 | Pass@k Training | 2025 | Same as GRPO's | Yes | Yes | Pass@k metric as reward | Group-based reward | [Paper](https://arxiv.org/abs/2508.10751) | [Code](https://github.com/RUCAIBox/Passk_Training) |
 | KTAE | 2025 | Same as GRPO's | Yes | Yes | Token-level advantage estimation | Group-based reward | [Paper](https://arxiv.org/pdf/2505.16826) | [Code](https://github.com/ZNLP/KTAE) |
+| DRACO | 2026 | Same as GRPO's | Yes | Yes | Rubric-attributed step-level advantage redistribution (outcome-blind) | Group-based rubric reward (LLM judge) | [Paper](https://arxiv.org/abs/2609.04094) | [Code](https://github.com/IBM/draco) |
 
 
 ## Sec4.1 Task: Search & Research Agent


### PR DESCRIPTION
This PR adds our recent paper to the **Sec2.7 Agentic RL: Algorithms** section, following the existing entry format.

**DRACO: Fine-Grained Credit Assignment with Dynamic Rubrics for Long-Horizon Agent Training**  
Shubham Gandhi, Saurabh Goyal, Kiran Kate, Yara Rizk (Carnegie Mellon University / IBM Research). arXiv 2609.04094, September 2026.
- Paper: https://arxiv.org/abs/2609.04094
- Code: https://github.com/IBM/draco

**Summary.** DRACO trains long-horizon tool-using agents with RL in the outcome-blind setting, where no verifier or ground-truth success signal is available. It generates task-specific rubrics dynamically during training, scores each finished trajectory once with an LLM judge, and redistributes the resulting GRPO advantage across steps in closed form using the judge's per-criterion attributions, with no learned attribution module. On AppWorld it gains 15.9 points over the base model and 5.3 points over GRPO trained on the ground-truth unit-test reward, and it transfers zero-shot to τ-Bench.

**Why here.** It is a GRPO variant for agentic RL that changes the advantage computation (rubric-attributed step-level redistribution) while keeping clipping and the KL penalty as in GRPO, so it fits the algorithms table.

I am an author of the paper. Happy to move the entry to a different section or adjust the format if you prefer.
